### PR TITLE
fix: Test workflow not receiving secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       name: Start maintenance window
       uses: ./start
       with:
-        app-url: ${{ secrets.MAINTZ_FUNC_URL }}
-        app-key: ${{ secrets.MAINTZ_FUNC_APP_KEY }}
+        app-url: '${{ secrets.MAINTZ_FUNC_URL }}'
+        app-key: '${{ secrets.MAINTZ_FUNC_APP_KEY }}'
         monitor-id: '63332000012700001' # Glider-Staging - our test monitor
         duration: 1 # 1 minute


### PR DESCRIPTION
Closes #46 

A small syntax error was preventing the secrets from being passed to the action. Turns out the `'${{ secrets.XYZZY }}'` syntax really needs the quotes for it to work.