### PR TITLE
build: Add auto-bump of major tag on release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -65,3 +65,8 @@ jobs:
 
           ${{ steps.update-changelog.outputs.release-notes }}
         labels: autorelease
+
+    - name: Output summary
+      run: |
+        echo "::notice title=Release PR Prepared::A release PR has been created, please merge it to continue with the release process: ${{ steps.create-release-pr.outputs.pull-request-url }}"
+  

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,43 @@
+on:
+  release:
+    types: [published]
+
+
+name: '[autorelease] Release published'
+
+jobs:
+  update-ref:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Get release version
+      id: get-release-version
+      run: |
+        VERSION="${{ github.event.release.tag_name }}"
+        RE='^[vV]?([0-9]+)[.]([0-9]+)[.]([0-9]+)(-[0-9A-Za-z.+-]*)?'
+        if [[ $VERSION =~ $RE ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          PRERELEASE="${BASH_REMATCH[4]}"
+        else
+          echo "::error::Version '$VERSION' is not in a valid format" && exit 1
+        fi
+        echo "::set-output name=major-ref::v$MAJOR"
+        if [[ "$PRERELEASE" ]]; then pre=true; else pre=false; fi
+        echo "::set-output name=is-prerelease::$pre"
+    - name: Prerelease
+      if: fromJSON(steps.get-release-version.outputs.is-prerelease)
+      run: |
+        echo "::notice::Pre-release version detected, not moving ref  ${{ steps.get-release-version.outputs.major-ref }}"
+    - name: Update release tag
+      if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
+      run: |        
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git tag -fa ${{ steps.get-release-version.outputs.major-ref }} -m "Update ${{ steps.get-release-version.outputs.major-ref }} tag"
+        git push origin ${{ steps.get-release-version.outputs.major-ref }} --force
+        echo "::notice::Updated ref ${{ steps.get-release-version.outputs.major-ref }}"


### PR DESCRIPTION
Add `release-published.yml` workflow to auto-bump the major tag (e.g. `v1`) to point at the latest release (e.g. `v1.2.3`).