### PR TITLE
build: Use PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,6 +41,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.TAGRELEASEBOT_APP_ID }}
+        private_key: ${{ secrets.TAGRELEASEBOT_APP_KEY }}
+
     - name: Update changelog
       id: update-changelog
       uses: release-flow/keep-a-changelog-action/prepare-release@v1
@@ -65,6 +71,7 @@ jobs:
 
           ${{ steps.update-changelog.outputs.release-notes }}
         labels: autorelease
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Output summary
       run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -72,6 +72,7 @@ jobs:
           ${{ steps.update-changelog.outputs.release-notes }}
         labels: autorelease
         token: ${{ steps.generate-token.outputs.token }}
+        delete-branch: true
 
     - name: Output summary
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Added
+
+- Use PAT instead of GITHUB_TOKEN to enable triggering workflows when a PR is created
+
 ## [0.1.0] - 2022-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ to all the actions in this repository.
 [This
 article](https://mbs.atlassian.net/wiki/spaces/DO/pages/2419523603/Creating+an+Azure+Function+App+Service+Connection/)
 documents how to find out the values to use for these parameters.
+
+### Credits
+
+[Rocket Icon Vectors by Vecteezy](https://www.vecteezy.com/free-vector/rocket-icon)


### PR DESCRIPTION
Use a `tagreleasebot` PAT instead of `GITHUB_TOKEN` so that it triggers the various workflows when the bot creates a PR.